### PR TITLE
Update generateThirdPartyLicense.js

### DIFF
--- a/tools/generateThirdPartyLicense.js
+++ b/tools/generateThirdPartyLicense.js
@@ -39,7 +39,7 @@ thirdPartyChecker.getLicenses(rootDir, (err, packages, checker) => {
     }
 
     // Check if we already added this package
-    if (addedKeys.hasOwnProperty(packageName)) {
+    if (Object.hasOwnProperty.prototype.call(addedKeys, packageName)) {
       return
     }
     addedKeys[packageName] = 1


### PR DESCRIPTION
Resolved deepsource issue.
- `Object.prototype` builtins should not be used directly

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | yes
| Deprecations?     | no
| New tests added?  | no
| License           | MIT